### PR TITLE
Fixed naming convention for the UDF

### DIFF
--- a/snowflake_native_app_ilike/scripts/setup.sql
+++ b/snowflake_native_app_ilike/scripts/setup.sql
@@ -15,12 +15,12 @@ CREATE OR REPLACE PROCEDURE code_schema.init_app(config variant)
 
 GRANT USAGE ON PROCEDURE code_schema.init_app(variant) TO APPLICATION ROLE app_public;
 
-CREATE OR REPLACE FUNCTION code_schema.skyflowSearch(vault_url string, table_name string, column_name string, name_to_search string)
+CREATE OR REPLACE FUNCTION code_schema.skyflow_search(vault_url string, table_name string, column_name string, name_to_search string)
   RETURNS string
   LANGUAGE python
   runtime_version = '3.8'
   packages = ('snowflake-snowpark-python', 'pyjwt', 'cryptography', 'requests', 'simplejson')
   imports = ('/src/udf.py')
-  handler = 'udf.skyflowSearch';
+  handler = 'udf.skyflow_search';
 
-GRANT USAGE ON FUNCTION code_schema.skyflowSearch(string, string, string, string) TO APPLICATION ROLE app_public;
+GRANT USAGE ON FUNCTION code_schema.skyflow_search(string, string, string, string) TO APPLICATION ROLE app_public;

--- a/snowflake_native_app_ilike/src/udf.py
+++ b/snowflake_native_app_ilike/src/udf.py
@@ -20,8 +20,7 @@ def get_signed_jwt(credentials):
    # Sign the claims object with the private key contained in the creds object
    signedJWT = jwt.encode(claims, credentials["privateKey"], algorithm='RS256') 
 
-   return signedJWT, credentials  
-
+   return signedJWT, credentials
 
 def get_bearer_token(signed_jwt, credentials):
    # Request body parameters
@@ -58,7 +57,7 @@ def init_app(session: Session, config) -> str:
   external_access_integration_name = config['external_access_integration_name']
 
   alter_function_sql = f'''
-    ALTER FUNCTION code_schema.skyflowSearch(string, string, string, string) SET 
+    ALTER FUNCTION code_schema.skyflow_search(string, string, string, string) SET 
     SECRETS = ('token' = {secret_name}) 
     EXTERNAL_ACCESS_INTEGRATIONS = ({external_access_integration_name})'''
   
@@ -66,9 +65,9 @@ def init_app(session: Session, config) -> str:
 
   return 'Skyflow app initialized'
 
-def skyflowSearch(vault_url, table_name, column_name, name_to_search):
+def skyflow_search(vault_url, table_name, column_name, name_to_search):
   """
-    skyflowSearch performs an ILIKE query within a specified vault and retrieves the data.
+    skyflow_search performs an ILIKE query within a specified vault and retrieves the data.
 
     Args:
         vault_url (str): The API URL of the vault where the tokenized data is stored. Must be of the form: https://identifier.vault.skyflowapis.com/v1/vaults/{vaultID}


### PR DESCRIPTION
Updated the naming for the Skyflow search function to skyflow_search to be consistent with Python and Snowflake conventions.